### PR TITLE
easy-xxe: make it ready to run by adding .env file

### DIFF
--- a/easy-xxe/.env
+++ b/easy-xxe/.env
@@ -1,0 +1,1 @@
+FLASK_APP=project


### PR DESCRIPTION
It appears `.env` is required for the Docker magic to work easily. `FLASK_APP=project` correctly selects the project.